### PR TITLE
Data src s3 creds

### DIFF
--- a/tools/java-iceberg-cli/src/main/java/iceberg/IcebergConnector.java
+++ b/tools/java-iceberg-cli/src/main/java/iceberg/IcebergConnector.java
@@ -446,6 +446,11 @@ public class IcebergConnector extends MetastoreConnector
         
         PartitionSpec ps = iceberg_table.spec();
 
+        // Checking whether separate source credentials are declared.
+        // If yes, use those, other set it to the default credentials.
+        // We also need to set the source configuration accordingly,
+        // for hadoop FileSystem to use it correctly.
+
         AwsBasicCredentials awsCreds;
         String srcAccessKeyId = System.getenv("SOURCE_AWS_ACCESS_KEY_ID");
         String srcSecretKey = System.getenv("SOURCE_AWS_SECRET_ACCESS_KEY");


### PR DESCRIPTION
GitHub issue link:

Problem: The current commitTable mechanism assumes that the source data-files and catalog are both accessible via the same s3 credentials. That may not always be true.

Solution: Add a check for additional environment variables in the commitTable functions. If declared, the source s3 credentials are accordingly set. Currently this check if done only within commitTable action. However, we can also create a global function, if desired.

Testing:

- [ ] Unit tests 
- [ ] Additional tests (add results below)

Documentation:
- [ ] Documentation not needed
- [ ] Updated README file
- [ ] Documentation prepared (provide link below)
